### PR TITLE
Update client repo url and remove grantnet engines

### DIFF
--- a/Config/config.json
+++ b/Config/config.json
@@ -1,6 +1,6 @@
 {
     "client_version"  : 38,
-    "client_repo_url" : "https://github.com/AndyGrant/OpenBench",
+    "client_repo_url" : "https://github.com/official-clockwork/OpenBench",
     "client_repo_ref" : "master",
 
     "use_cross_approval"          : false,
@@ -24,26 +24,6 @@
     ],
 
     "engines" : [
-        "4ku",
-        "Berserk",
-        "Bit-Genie",
-        "BlackMarlin",
-        "Clockwork",
-        "Demolito",
-        "Drofa",
-        "Equisetum",
-        "Ethereal",
-        "FabChess",
-        "Halogen",
-        "Igel",
-        "Koivisto",
-        "Laser",
-        "RubiChess",
-        "Seer",
-        "Stash",
-        "Stockfish",
-        "Weiss",
-        "Winter",
-        "Zahak"
+        "Clockwork"
     ]
 }


### PR DESCRIPTION
Not sure if comments in .json would break anything, so removing just in case.

And more importantly, updating the client repo url before we get crazy trying to understand why future OB customizations don't work.