### PR TITLE
When copying SPRT results, add test branch and triple code quotes

### DIFF
--- a/OpenBench/static/copy_text.js
+++ b/OpenBench/static/copy_text.js
@@ -1,8 +1,10 @@
 
 function copy_text(element_id, keep_url) {
 
-    var text = document.getElementById(element_id).innerHTML;
+    var text = "```\n";
+    text += document.getElementById(element_id).innerHTML;
     text = text.replace(/<br>/g, "\n");
+    text += "\n```";
 
     if (keep_url)
         text += "\n" + window.location.href;

--- a/OpenBench/templatetags/mytags.py
+++ b/OpenBench/templatetags/mytags.py
@@ -99,6 +99,7 @@ def longStatBlock(test):
     lower, elo, upper = OpenBench.stats.Elo(test.results())
 
     lines = [
+        'Test  | %s' % (prettyDevName(test)),
         'Elo   | %0.2f +- %0.2f (95%%)' % (elo, max(upper - elo, elo - lower)),
         '%-5s | %s Threads=%d Hash=%dMB' % (type_text, timecontrol, threads, hashmb),
     ]


### PR DESCRIPTION
Before:

Elo   | 16.60 +- 8.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3938 W: 1470 L: 1282 D: 1186
Penta | [185, 368, 728, 450, 238]
https://clockworkopenbench.pythonanywhere.com/test/38/

After:
```
Test  | killer2
Elo   | 16.60 +- 8.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3938 W: 1470 L: 1282 D: 1186
Penta | [185, 368, 728, 450, 238]
```
https://clockworkopenbench.pythonanywhere.com/test/38/